### PR TITLE
Fixed contact us link inside mobile menu

### DIFF
--- a/client/src/components/Navbar/MobileNav/index.tsx
+++ b/client/src/components/Navbar/MobileNav/index.tsx
@@ -70,7 +70,7 @@ const MobileNav = () => {
         <div className={`menuFooterWrapper ${isOpen ? "open" : ""}`}>
           <div className={`menuFooter ${isOpen ? "open" : ""}`}>
             {/* Contact container */}
-            <Link to="/contact-us">
+            <Link to="/contact-us" onClick={() => setIsOpen(false)}>
               <div className="contactUs">
                 <MdOutlineMail className="contactIcon" size={24} />
                 <p className="contactText">Contact Us</p>

--- a/client/src/pages/category/category.tsx
+++ b/client/src/pages/category/category.tsx
@@ -25,7 +25,6 @@ const CategoryPage = () => {
             "slug": slug.current
           }`;
           const data: simpleProduct[] = await client.fetch(query, { category });
-          console.log("Fetched data:", data);
           setCategoryData(data);
           setLoading(false);
         } catch (error) {


### PR DESCRIPTION
Fixed an issue where when clicking on the contact us link inside the `mobileNav` menu  wouldn't close the menu, fixed it by adding an onClick callback function to set the setIsOpen function to false 
